### PR TITLE
Usability improvements and simplification

### DIFF
--- a/include/tf_service/buffer_server.h
+++ b/include/tf_service/buffer_server.h
@@ -26,6 +26,12 @@
 
 namespace tf_service {
 
+struct ServerOptions {
+  ros::Duration cache_time = ros::Duration(tf2_ros::Buffer::DEFAULT_CACHE_TIME);
+  ros::Duration max_timeout = ros::Duration(10);
+  bool debug = false;
+};
+
 // Exposes TF lookup as a ROS service.
 // Since TF buffer lookups are thread-safe, this class can be used with parallel
 // callback handlers.
@@ -33,7 +39,8 @@ class Server {
  public:
   Server() = delete;
 
-  Server(std::shared_ptr<ros::NodeHandle> private_node_handle);
+  Server(std::shared_ptr<ros::NodeHandle> private_node_handle,
+         const ServerOptions& options);
 
   bool handleLookupTransform(tf_service::LookupTransformRequest& request,
                              tf_service::LookupTransformResponse& response);
@@ -43,8 +50,9 @@ class Server {
 
  private:
   std::shared_ptr<ros::NodeHandle> private_node_handle_;
+  ServerOptions options_;
   std::vector<ros::ServiceServer> service_servers_;
-  tf2_ros::Buffer tf_buffer_;
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 

--- a/include/tf_service/buffer_server.h
+++ b/include/tf_service/buffer_server.h
@@ -39,8 +39,7 @@ class Server {
  public:
   Server() = delete;
 
-  Server(std::shared_ptr<ros::NodeHandle> private_node_handle,
-         const ServerOptions& options);
+  Server(const ServerOptions& options);
 
   bool handleLookupTransform(tf_service::LookupTransformRequest& request,
                              tf_service::LookupTransformResponse& response);
@@ -49,11 +48,10 @@ class Server {
                           tf_service::CanTransformResponse& response);
 
  private:
-  std::shared_ptr<ros::NodeHandle> private_node_handle_;
   ServerOptions options_;
   std::vector<ros::ServiceServer> service_servers_;
-  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
 };
 
 }  // namespace tf_service

--- a/src/buffer_server.cc
+++ b/src/buffer_server.cc
@@ -21,10 +21,13 @@
 
 namespace tf_service {
 
-Server::Server(std::shared_ptr<ros::NodeHandle> private_node_handle)
-    : private_node_handle_(private_node_handle) {
-  tf_buffer_.setUsingDedicatedThread(true);
-  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_);
+Server::Server(std::shared_ptr<ros::NodeHandle> private_node_handle,
+               const ServerOptions& options)
+    : private_node_handle_(private_node_handle), options_(options) {
+  tf_buffer_ =
+      std::make_unique<tf2_ros::Buffer>(options_.cache_time, options_.debug);
+  tf_buffer_->setUsingDedicatedThread(true);
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
   service_servers_.push_back(private_node_handle_->advertiseService(
       kLookupTransformServiceName, &Server::handleLookupTransform, this));
   service_servers_.push_back(private_node_handle_->advertiseService(
@@ -34,25 +37,24 @@ Server::Server(std::shared_ptr<ros::NodeHandle> private_node_handle)
 bool Server::handleLookupTransform(
     tf_service::LookupTransformRequest& request,
     tf_service::LookupTransformResponse& response) {
-  // TODO make sure not to block forever if someone sends a long timeout.
-  // TODO move to client?
-  if (request.timeout > ros::Duration(kMaxAllowedTimeout)) {
+  // Make sure not to block forever if someone sends a long timeout.
+  if (request.timeout > options_.max_timeout) {
     response.status.error = tf2_msgs::TF2Error::INVALID_ARGUMENT_ERROR;
-    response.status.error_string = "Requests with a timeout above " +
-                                   std::to_string(kMaxAllowedTimeout) +
-                                   " are not supported.";
+    response.status.error_string =
+        "Server is configured to block requests with a timeout above " +
+        std::to_string(options_.max_timeout.toSec()) + " seconds.";
     return true;
   }
   geometry_msgs::TransformStamped transform;
   try {
     if (request.advanced) {
-      transform = tf_buffer_.lookupTransform(
+      transform = tf_buffer_->lookupTransform(
           request.target_frame, request.target_time, request.source_frame,
           request.source_time, request.fixed_frame, request.timeout);
     } else {
-      transform =
-          tf_buffer_.lookupTransform(request.target_frame, request.source_frame,
-                                     request.time, request.timeout);
+      transform = tf_buffer_->lookupTransform(request.target_frame,
+                                              request.source_frame,
+                                              request.time, request.timeout);
     }
   } catch (const tf2::ConnectivityException& exception) {
     response.status.error = tf2_msgs::TF2Error::CONNECTIVITY_ERROR;
@@ -87,13 +89,20 @@ bool Server::handleLookupTransform(
 
 bool Server::handleCanTransform(tf_service::CanTransformRequest& request,
                                 tf_service::CanTransformResponse& response) {
+  if (request.timeout > options_.max_timeout) {
+    response.can_transform = false;
+    response.errstr =
+        "Server is configured to block requests with a timeout above " +
+        std::to_string(options_.max_timeout.toSec()) + " seconds.";
+    return true;
+  }
   if (request.advanced) {
-    response.can_transform = tf_buffer_.canTransform(
+    response.can_transform = tf_buffer_->canTransform(
         request.target_frame, request.target_time, request.source_frame,
         request.source_time, request.fixed_frame, request.timeout,
         &response.errstr);
   } else {
-    response.can_transform = tf_buffer_.canTransform(
+    response.can_transform = tf_buffer_->canTransform(
         request.target_frame, request.source_frame, request.time,
         request.timeout, &response.errstr);
   }

--- a/src/server_main.cc
+++ b/src/server_main.cc
@@ -66,10 +66,9 @@ int main(int argc, char** argv) {
   options.debug = vm.count("debug");
 
   ros::init(argc, argv, "tf_service");
-  auto private_node_handle = std::make_shared<ros::NodeHandle>("~");
 
   ROS_INFO_STREAM("Starting server with " << num_threads << " handler threads");
-  tf_service::Server server(private_node_handle, options);
+  tf_service::Server server(options);
   ros::AsyncSpinner spinner(num_threads);
   spinner.start();
   ros::waitForShutdown();

--- a/src/server_main.cc
+++ b/src/server_main.cc
@@ -31,6 +31,11 @@ int main(int argc, char** argv) {
     ("help", "show usage")
     ("num_threads", po::value<int>(&num_threads)->default_value(10),
      "Number of handler threads. 0 means number of CPU cores.")
+    ("cache_time", po::value<double>(),
+     "Buffer cache time of the underlying TF buffer in seconds.")
+    ("max_timeout", po::value<double>(),
+     "Requests with lookup timeouts (seconds) above this will be blocked.")
+    ("debug", "Enables debugging features.")
   ;
   // clang-format on
   po::variables_map vm;
@@ -53,11 +58,18 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
+  tf_service::ServerOptions options;
+  if (vm.count("cache_time"))
+    options.cache_time = ros::Duration(vm["cache_time"].as<double>());
+  if (vm.count("max_timeout"))
+    options.max_timeout = ros::Duration(vm["max_timeout"].as<double>());
+  options.debug = vm.count("debug");
+
   ros::init(argc, argv, "tf_service");
   auto private_node_handle = std::make_shared<ros::NodeHandle>("~");
 
   ROS_INFO_STREAM("Starting server with " << num_threads << " handler threads");
-  tf_service::Server server(private_node_handle);
+  tf_service::Server server(private_node_handle, options);
   ros::AsyncSpinner spinner(num_threads);
   spinner.start();
   ros::waitForShutdown();

--- a/src/tf_service/client.py
+++ b/src/tf_service/client.py
@@ -35,6 +35,9 @@ class BufferClient(tf2_ros.BufferInterface):
 
     @translate_exceptions
     def __init__(self, server_node_name):
+        """
+        :param server_node_name: name of the tf_service server ROS node
+        """
         tf2_ros.BufferInterface.__init__(self)
         # All actual work is done by the C++ binding.
         self.client = client_binding.BufferClientBinding(server_node_name)

--- a/src/tf_service/decorators.py
+++ b/src/tf_service/decorators.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 import tf2_ros
 
 from tf_service import client_binding
@@ -20,6 +22,7 @@ from tf_service import client_binding
 # Decorator for class methods that translates internal exception types to
 # corresponding tf2_ros.*Exceptions.
 def translate_exceptions(method):
+    @functools.wraps(method)
     def translate(obj, *args, **kwargs):
         try:
             return_value = method(obj, *args, **kwargs)


### PR DESCRIPTION
*C++*

Add configurable server options.

Remove unnecessary smart pointers.

---
*Python*

Preserve original docstrings of decorated Python methods.

Without `functools.wraps` the signature of the decorator would be shown
in help functions.