### PR TITLE
Compatibility with old pybind11 from Ubuntu.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/pybind11"]
-	path = 3rdparty/pybind11
-	url = https://github.com/pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 find_package(Boost REQUIRED COMPONENTS filesystem program_options)
 
 # pybind11 is header-only.
-add_subdirectory(3rdparty/pybind11)
+find_package(pybind11)
 
 
 ##############

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -2,7 +2,6 @@ from ros:melodic
 
 RUN mkdir -p catkin_ws/src/tf_service
 COPY . catkin_ws/src/tf_service
-RUN git -C catkin_ws/src/tf_service submodule update --init
 
 # Build and test.
 RUN bash catkin_ws/src/tf_service/.ci/docker_build_catkin_ws.sh

--- a/NOTICE
+++ b/NOTICE
@@ -12,7 +12,3 @@ conditions of the following licenses.
 This product includes code from geometry2, copyright Willow Garage, Inc.,
 which is available under a BSD license.
 For details, see: 3rdparty/geometry2_LICENSE and http://wiki.ros.org/geometry2
-
-This product bundles a Git submodule of pybind11, copyright Wenzel Jakob,
-which is available under a BSD-style license.
-For details, see: 3rdparty/pybind11/LICENSE

--- a/README.md
+++ b/README.md
@@ -103,12 +103,10 @@ You can use the `wait_for_server` method with a timeout in case the connection w
 
 ### From source
 
-`git clone` the repo into your catkin workspace and run:
+`git clone` the repo into your catkin workspace, install the dependencies and run:
 
 ```bash
-cd tf_service
-git submodule update --init  # for pybind11 headers
-catkin build --this
+catkin build tf_service
 ```
 
 ---

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- TODO: use this instead of submodule
-             ...once the Ubuntu package is less broken:
-             https://bugs.launchpad.net/ubuntu/+source/pybind11/+bug/1779578 -->
-  <!-- <build_depend>pybind11-dev</build_depend> -->
+  <build_depend>pybind11-dev</build_depend> -->
 
   <depend>boost</depend>
   <depend>geometry_msgs</depend>

--- a/src/python_bindings/buffer_client_py.cc
+++ b/src/python_bindings/buffer_client_py.cc
@@ -39,12 +39,11 @@ static void ros_init_once() {
 }
 
 // Python module "client", will be <pkg_name>.client after catkin build.
-PYBIND11_MODULE(client_binding, m) {
+// TODO: use PYBIND11_MODULE in new versions, see other TODO at end of macro.
+PYBIND11_PLUGIN(client_binding) {
+  py::module m("client_binding");
   py::class_<tfs::BufferClient>(m, "BufferClientBinding")
-      .def(py::init([](const std::string& server_node_name) {
-             ros_init_once();
-             return std::make_unique<tfs::BufferClient>(server_node_name);
-           }),
+      .def(py::init<const std::string&>(),
            /* doc strings for args */
            py::arg("server_node_name"))
       .def("can_transform",
@@ -87,6 +86,9 @@ PYBIND11_MODULE(client_binding, m) {
       .def("wait_for_server", &tfs::BufferClient::waitForServer,
            /* doc strings for args */
            py::arg("timeout"));
+
+  // Needs to be called in Python code.
+  m.def("roscpp_init_once", &ros_init_once);
 
   // Intended for use in Python shutdown hooks.
   m.def("roscpp_shutdown", &ros::requestShutdown);
@@ -148,4 +150,7 @@ PYBIND11_MODULE(client_binding, m) {
       TimeoutExceptionPy(e.what());
     }
   });
+
+  // TODO: obsolete with PYBIND11_MODULE
+  return m.ptr();
 }

--- a/src/tf_service/client.py
+++ b/src/tf_service/client.py
@@ -40,6 +40,7 @@ class BufferClient(tf2_ros.BufferInterface):
         """
         tf2_ros.BufferInterface.__init__(self)
         # All actual work is done by the C++ binding.
+        client_binding.roscpp_init_once()
         self.client = client_binding.BufferClientBinding(server_node_name)
         rospy.on_shutdown(client_binding.roscpp_shutdown)
 


### PR DESCRIPTION
Luckily this only affects two smaller things (different macro signature
and lambda support). It's also forward-compatible with the current
upstream of pybind11, although with a deprecation warning.

Note: documentation for this old version can be fetched by installing
pybind11-doc (then in /usr/share/pybind11-doc).