### PR TITLE
Support for ROS Noetic / Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,9 @@ os:
 services:
   - docker
 
+env:
+  - ROS_DISTRO=melodic
+  - ROS_DISTRO=noetic
+
 script:
-  - docker build . --file Dockerfile.melodic --tag tf_service:test || exit 1
+  - docker build . --file Dockerfile.${ROS_DISTRO} --tag tf_service:test || exit 1

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -1,0 +1,10 @@
+from ros:noetic
+
+RUN mkdir -p catkin_ws/src/tf_service
+COPY . catkin_ws/src/tf_service
+
+# Build and test.
+RUN bash catkin_ws/src/tf_service/.ci/docker_build_catkin_ws.sh
+
+# Source ROS setup before running as a container.
+ENTRYPOINT ["catkin_ws/src/tf_service/.ci/docker_ros_entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ TF buffer server / client implementation based on ROS services.
 
 Implemented in C++ and Python bindings.
 
-[![Build Status](https://travis-ci.org/magazino/tf_service.svg?branch=master)](https://travis-ci.org/magazino/tf_service)
+| ROS noetic / melodic |
+| :---: |
+| [![Build Status](https://travis-ci.org/magazino/tf_service.svg?branch=master)](https://travis-ci.org/magazino/tf_service) |
 
 ---
 

--- a/src/tf_service/__init__.py
+++ b/src/tf_service/__init__.py
@@ -1,1 +1,1 @@
-from client import BufferClient
+from .client import BufferClient


### PR DESCRIPTION
This will allow us to build Noetic on Jenkins & GitHub PR checks. 

* Add Dockerfile for Noetic and run it in Travis CI.
* Use explicit relative import for Python 3 support.