### PR TITLE
Allow running a legacy tf2::BufferServer in the same node.

### DIFF
--- a/include/tf_service/buffer_server.h
+++ b/include/tf_service/buffer_server.h
@@ -19,6 +19,7 @@
 
 #include "ros/ros.h"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/buffer_server.h"
 #include "tf2_ros/transform_listener.h"
 
 #include "tf_service/CanTransform.h"
@@ -30,6 +31,8 @@ struct ServerOptions {
   ros::Duration cache_time = ros::Duration(tf2_ros::Buffer::DEFAULT_CACHE_TIME);
   ros::Duration max_timeout = ros::Duration(10);
   bool debug = false;
+  bool add_legacy_server = false;
+  std::string legacy_server_namespace = "";
 };
 
 // Exposes TF lookup as a ROS service.
@@ -39,7 +42,7 @@ class Server {
  public:
   Server() = delete;
 
-  Server(const ServerOptions& options);
+  explicit Server(const ServerOptions& options);
 
   bool handleLookupTransform(tf_service::LookupTransformRequest& request,
                              tf_service::LookupTransformResponse& response);
@@ -52,6 +55,7 @@ class Server {
   std::vector<ros::ServiceServer> service_servers_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
+  std::unique_ptr<tf2_ros::BufferServer> optional_legacy_server_;
 };
 
 }  // namespace tf_service

--- a/src/buffer_server.cc
+++ b/src/buffer_server.cc
@@ -35,10 +35,7 @@ Server::Server(const ServerOptions& options)
       kCanTransformServiceName, &Server::handleCanTransform, this));
   if (options_.add_legacy_server) {
     optional_legacy_server_ = std::make_unique<tf2_ros::BufferServer>(
-        std::cref(tf_buffer_),
-        options_.legacy_server_namespace.empty()
-            ? ros::this_node::getName()
-            : options_.legacy_server_namespace,
+        std::cref(tf_buffer_), options_.legacy_server_namespace,
         false /* auto_start */);
     optional_legacy_server_->start();
   }

--- a/src/buffer_server.cc
+++ b/src/buffer_server.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <functional>
+
 #include "tf_service/buffer_server.h"
 
 #include "geometry_msgs/TransformStamped.h"
@@ -31,6 +33,15 @@ Server::Server(const ServerOptions& options)
       kLookupTransformServiceName, &Server::handleLookupTransform, this));
   service_servers_.push_back(private_node_handle.advertiseService(
       kCanTransformServiceName, &Server::handleCanTransform, this));
+  if (options_.add_legacy_server) {
+    optional_legacy_server_ = std::make_unique<tf2_ros::BufferServer>(
+        std::cref(tf_buffer_),
+        options_.legacy_server_namespace.empty()
+            ? ros::this_node::getName()
+            : options_.legacy_server_namespace,
+        false /* auto_start */);
+    optional_legacy_server_->start();
+  }
 }
 
 bool Server::handleLookupTransform(

--- a/src/server_main.cc
+++ b/src/server_main.cc
@@ -37,6 +37,9 @@ int main(int argc, char** argv) {
      "Requests with lookup timeouts (seconds) above this will be blocked.")
     ("frames_service", "Advertise the tf2_frames service.")
     ("debug", "Advertise the tf2_frames service (same as --frames_service).")
+    ("add_legacy_server", "If set, also run a tf2_ros::BufferServer.")
+    ("legacy_server_namespace", po::value<std::string>()->default_value(""),
+     "Use a separate namespace for the legacy action server.")
   ;
   // clang-format on
   po::variables_map vm;
@@ -65,10 +68,15 @@ int main(int argc, char** argv) {
   if (vm.count("max_timeout"))
     options.max_timeout = ros::Duration(vm["max_timeout"].as<double>());
   options.debug = vm.count("frames_service") || vm.count("debug");
+  options.add_legacy_server = vm.count("add_legacy_server");
+  options.legacy_server_namespace =
+      vm["legacy_server_namespace"].as<std::string>();
 
   ros::init(argc, argv, "tf_service");
 
   ROS_INFO_STREAM("Starting server with " << num_threads << " handler threads");
+  ROS_INFO_COND(options.add_legacy_server,
+                "Also starting a legacy tf2::BufferServer.");
   tf_service::Server server(options);
   ros::AsyncSpinner spinner(num_threads);
   spinner.start();

--- a/test/client_rostest.cc
+++ b/test/client_rostest.cc
@@ -15,68 +15,79 @@
 #include "gtest/gtest.h"
 #include "tf2/exceptions.h"
 
+#include "tf2_ros/buffer_client.h"
 #include "tf_service/buffer_client.h"
 
+// Tests both the tf_service and the optional legacy functionality.
 // See rostest launch file.
 constexpr char kExpectedServerName[] = "/tf_service";
+constexpr char kExpectedLegacyServerName[] = "/tf2_buffer_server";
 constexpr char kExpectedTargetFrame[] = "map";
 constexpr char kExpectedSourceFrame[] = "odom";
 
-TEST(ClientRostest, waitForServerSucceeds) {
+class ClientRostest
+    : public testing::TestWithParam<std::shared_ptr<tf2_ros::BufferInterface>> {
+};
+
+TEST_P(ClientRostest, waitForServerSucceeds) {
+  // This only applies to tf_service::BufferClient, so no GetParam() here.
   tf_service::BufferClient buffer(kExpectedServerName);
   EXPECT_TRUE(buffer.waitForServer(ros::Duration(0.1)));
   EXPECT_TRUE(buffer.isConnected());
 }
 
-TEST(ClientRostest, waitForServerFails) {
+TEST_P(ClientRostest, waitForServerFails) {
+  // This only applies to tf_service::BufferClient, so no GetParam() here.
   tf_service::BufferClient buffer("/wrong_server_name");
   EXPECT_FALSE(buffer.waitForServer(ros::Duration(0.1)));
   EXPECT_FALSE(buffer.isConnected());
 }
 
-TEST(ClientRostest, canTransform) {
-  tf_service::BufferClient buffer(kExpectedServerName);
-  EXPECT_TRUE(buffer.waitForServer(ros::Duration(0.1)));
-  EXPECT_TRUE(buffer.canTransform(kExpectedTargetFrame, kExpectedSourceFrame,
-                                  ros::Time(0), ros::Duration(0.1)));
+TEST_P(ClientRostest, canTransform) {
+  auto buffer = GetParam();
+  EXPECT_TRUE(buffer->canTransform(kExpectedTargetFrame, kExpectedSourceFrame,
+                                   ros::Time(0), ros::Duration(0.1)));
   EXPECT_FALSE(
-      buffer.canTransform("bla", "blub", ros::Time(0), ros::Duration(0.1)));
+      buffer->canTransform("bla", "blub", ros::Time(0), ros::Duration(0.1)));
 }
 
-TEST(ClientRostest, canTransformAdvanced) {
-  tf_service::BufferClient buffer(kExpectedServerName);
-  EXPECT_TRUE(buffer.waitForServer(ros::Duration(0.1)));
-  EXPECT_TRUE(buffer.canTransform(kExpectedTargetFrame, ros::Time(0),
-                                  kExpectedSourceFrame, ros::Time(0),
-                                  kExpectedTargetFrame, ros::Duration(0.1)));
-  EXPECT_FALSE(buffer.canTransform("bla", ros::Time(0), "blub", ros::Time(0),
-                                   "bla", ros::Duration(0.1)));
+TEST_P(ClientRostest, canTransformAdvanced) {
+  auto buffer = GetParam();
+  EXPECT_TRUE(buffer->canTransform(kExpectedTargetFrame, ros::Time(0),
+                                   kExpectedSourceFrame, ros::Time(0),
+                                   kExpectedTargetFrame, ros::Duration(0.1)));
+  EXPECT_FALSE(buffer->canTransform("bla", ros::Time(0), "blub", ros::Time(0),
+                                    "bla", ros::Duration(0.1)));
 }
 
-TEST(ClientRostest, lookupTransform) {
-  tf_service::BufferClient buffer(kExpectedServerName);
-  EXPECT_TRUE(buffer.waitForServer(ros::Duration(0.1)));
+TEST_P(ClientRostest, lookupTransform) {
+  auto buffer = GetParam();
   EXPECT_NO_FATAL_FAILURE(
-      buffer.lookupTransform(kExpectedTargetFrame, kExpectedSourceFrame,
-                             ros::Time(0), ros::Duration(0.1)));
+      buffer->lookupTransform(kExpectedTargetFrame, kExpectedSourceFrame,
+                              ros::Time(0), ros::Duration(0.1)));
   EXPECT_THROW(
-      buffer.lookupTransform("bla", "blub", ros::Time(0), ros::Duration(0.1)),
+      buffer->lookupTransform("bla", "blub", ros::Time(0), ros::Duration(0.1)),
       tf2::LookupException);
 }
 
-TEST(ClientRostest, lookupTransformAdvanced) {
-  tf_service::BufferClient buffer(kExpectedServerName);
-  EXPECT_TRUE(buffer.waitForServer(ros::Duration(0.1)));
-  EXPECT_NO_FATAL_FAILURE(buffer.lookupTransform(
+TEST_P(ClientRostest, lookupTransformAdvanced) {
+  auto buffer = GetParam();
+  EXPECT_NO_FATAL_FAILURE(buffer->lookupTransform(
       kExpectedTargetFrame, ros::Time(0), kExpectedSourceFrame, ros::Time(0),
       kExpectedTargetFrame, ros::Duration(0.1)));
-  EXPECT_THROW(buffer.lookupTransform("bla", ros::Time(0), "blub", ros::Time(0),
-                                      "bla", ros::Duration(0.1)),
+  EXPECT_THROW(buffer->lookupTransform("bla", ros::Time(0), "blub",
+                                       ros::Time(0), "bla", ros::Duration(0.1)),
                tf2::LookupException);
 }
 
+INSTANTIATE_TEST_CASE_P(
+    AllClientRostests, ClientRostest,
+    testing::Values(
+        std::make_shared<tf_service::BufferClient>(kExpectedServerName),
+        std::make_shared<tf2_ros::BufferClient>(kExpectedLegacyServerName)));
+
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "client_rostest");
+  ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/client_rostest.launch
+++ b/test/client_rostest.launch
@@ -6,7 +6,12 @@
 
   <!-- Server -->
   <node name="tf_service" pkg="tf_service"
-        type="server" args="--num_threads 5" output="screen" required="true" />
+        type="server" args="
+          --num_threads 5
+          --add_legacy_server
+          --legacy_server_namespace /tf2_buffer_server
+        "
+        output="screen" required="true" />
 
   <!-- Test node -->
   <test test-name="client_rostest" pkg="tf_service"


### PR DESCRIPTION
Useful to avoid two separate nodes when both are used.

rostest is adapted to test that both interfaces are usable.