### PR TITLE
Fix leaking C++->Python cast of TransformStamped.header.stamp

### DIFF
--- a/src/python_bindings/casts/transform_stamped.h
+++ b/src/python_bindings/casts/transform_stamped.h
@@ -62,8 +62,7 @@ struct type_caster<geometry_msgs::TransformStamped> {
 
     tf.attr("header").attr("seq") = ::pybind11::cast(src.header.seq);
     tf.attr("header").attr("frame_id") = ::pybind11::cast(src.header.frame_id);
-    tf.attr("header").attr("stamp") =
-        type_caster<ros::Time>().cast(src.header.stamp, policy, parent);
+    tf.attr("header").attr("stamp") = ::pybind11::cast(src.header.stamp);
     tf.attr("child_frame_id") = ::pybind11::cast(src.child_frame_id);
     tf.attr("transform").attr("rotation").attr("w") =
         ::pybind11::cast(src.transform.rotation.w);


### PR DESCRIPTION
The manual call to our custom type_caster is missing an ownership
transfer, so the refcount is wrong. Stealing would be correct in this case:

```c++
tf.attr("header").attr("stamp") =
    ::pybind11::reinterpret_steal<object>(
        type_caster<ros::Time>().cast(src.header.stamp, policy, parent));
```

Overall, this is not necessary because `pybind11::cast` automatically
takes care of this and we can just use that instead.

Closes: #16