### PR TITLE
Add optional client cache

### DIFF
--- a/include/tf_service/buffer_client.h
+++ b/include/tf_service/buffer_client.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "ros/ros.h"
+#include "tf2/buffer_core.h"
 #include "tf2_ros/buffer_interface.h"
 
 namespace tf_service {
@@ -27,7 +28,9 @@ class BufferClient : public tf2_ros::BufferInterface {
  public:
   BufferClient() = delete;
 
-  BufferClient(const std::string& server_node_name);
+  BufferClient(const std::string& server_node_name,
+               const bool use_cache = false,
+               const ros::Duration cache_time = ros::Duration(10));
 
   ~BufferClient();
 
@@ -57,6 +60,8 @@ class BufferClient : public tf2_ros::BufferInterface {
   bool isConnected() const;
   bool waitForServer(const ros::Duration timeout = ros::Duration(-1));
 
+  void clearCache();
+
  private:
   mutable std::mutex mutex_;
 
@@ -65,6 +70,8 @@ class BufferClient : public tf2_ros::BufferInterface {
   // mutable because ServiceClient::call() isn't const.
   mutable ros::ServiceClient can_transform_client_;     // GUARDED_BY(mutex_);
   mutable ros::ServiceClient lookup_transform_client_;  // GUARDED_BY(mutex_);
+
+  std::unique_ptr<tf2::BufferCore> cache_;
 };
 
 }  // namespace tf_service

--- a/src/python_bindings/buffer_client_py.cc
+++ b/src/python_bindings/buffer_client_py.cc
@@ -43,9 +43,10 @@ static void ros_init_once() {
 PYBIND11_PLUGIN(client_binding) {
   py::module m("client_binding");
   py::class_<tfs::BufferClient>(m, "BufferClientBinding")
-      .def(py::init<const std::string&>(),
+      .def(py::init<const std::string&, const bool, const ros::Duration>(),
            /* doc strings for args */
-           py::arg("server_node_name"))
+           py::arg("server_node_name"), py::arg("use_cache"),
+           py::arg("cache_time"))
       .def("can_transform",
            py::overload_cast<const std::string&, const std::string&,
                              const ros::Time&, ros::Duration, std::string*>(
@@ -85,7 +86,8 @@ PYBIND11_PLUGIN(client_binding) {
            py::arg("timeout"))
       .def("wait_for_server", &tfs::BufferClient::waitForServer,
            /* doc strings for args */
-           py::arg("timeout"));
+           py::arg("timeout"))
+      .def("clear_cache", &tfs::BufferClient::clearCache);
 
   // Needs to be called in Python code.
   m.def("roscpp_init_once", &ros_init_once);

--- a/src/tf_service/client.py
+++ b/src/tf_service/client.py
@@ -34,15 +34,22 @@ class BufferClient(tf2_ros.BufferInterface):
     """
 
     @translate_exceptions
-    def __init__(self, server_node_name):
+    def __init__(self, server_node_name, use_cache=False,
+                 cache_time=rospy.Duration(10)):
         """
         :param server_node_name: name of the tf_service server ROS node
+        :param use_cache: whether to cache lookup results inside the client
+        :param cache_time: max. age of transforms in the cache
         """
         tf2_ros.BufferInterface.__init__(self)
         # All actual work is done by the C++ binding.
         client_binding.roscpp_init_once()
-        self.client = client_binding.BufferClientBinding(server_node_name)
+        self.client = client_binding.BufferClientBinding(
+            server_node_name, use_cache, cache_time)
         rospy.on_shutdown(client_binding.roscpp_shutdown)
+
+    def clear_cache(self):
+        self.client.clear_cache()
 
     @translate_exceptions
     def wait_for_server(self, timeout=rospy.Duration(-1)):


### PR DESCRIPTION
Allows to get repeated lookup requests from memory instead of calling
the service again. Can be configured in the client constructor in C++ & Python.