### PR TITLE
Add async reconnection and keepalive to client.

### DIFF
--- a/include/tf_service/buffer_client.h
+++ b/include/tf_service/buffer_client.h
@@ -28,7 +28,10 @@ class BufferClient : public tf2_ros::BufferInterface {
  public:
   BufferClient() = delete;
 
-  BufferClient(const std::string& server_node_name);
+  explicit BufferClient(const std::string& server_node_name);
+
+  BufferClient(const std::string& server_node_name,
+               const ros::Duration keepalive_period);
 
   ~BufferClient();
 
@@ -55,7 +58,7 @@ class BufferClient : public tf2_ros::BufferInterface {
                     std::string* errstr = NULL) const override;
 
   bool reconnect(ros::Duration timeout = ros::Duration(10));
-  void asyncReconnect(const ros::Duration timeout = ros::Duration(10));
+  void asyncReconnect(const ros::Duration timeout = ros::Duration(-1));
   bool isConnected() const;
   bool waitForServer(const ros::Duration timeout = ros::Duration(-1));
 
@@ -70,6 +73,7 @@ class BufferClient : public tf2_ros::BufferInterface {
   mutable ros::ServiceClient lookup_transform_client_;  // GUARDED_BY(mutex_);
 
   std::future<bool> async_reconnected_;
+  ros::Timer keepalive_timer_;
 };
 
 }  // namespace tf_service

--- a/include/tf_service/buffer_client.h
+++ b/include/tf_service/buffer_client.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <future>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -54,17 +55,21 @@ class BufferClient : public tf2_ros::BufferInterface {
                     std::string* errstr = NULL) const override;
 
   bool reconnect(ros::Duration timeout = ros::Duration(10));
+  void asyncReconnect(const ros::Duration timeout = ros::Duration(10));
   bool isConnected() const;
   bool waitForServer(const ros::Duration timeout = ros::Duration(-1));
 
  private:
   mutable std::mutex mutex_;
+  mutable std::mutex reconnection_mutex_;
 
   ros::NodeHandle node_handle_;
 
   // mutable because ServiceClient::call() isn't const.
   mutable ros::ServiceClient can_transform_client_;     // GUARDED_BY(mutex_);
   mutable ros::ServiceClient lookup_transform_client_;  // GUARDED_BY(mutex_);
+
+  std::future<bool> async_reconnected_;
 };
 
 }  // namespace tf_service

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosnode</test_depend>
 
   <export>
   </export>

--- a/src/buffer_client.cc
+++ b/src/buffer_client.cc
@@ -93,8 +93,10 @@ bool BufferClient::reconnect(ros::Duration timeout) {
     ROS_WARN("Already reconnecting to tf_service server.");
     return false;
   }
+  ROS_INFO_STREAM("Waiting for " << can_transform_client_.getService()
+                                 << " to become available.");
   if (!can_transform_client_.waitForExistence(timeout)) {
-    ROS_ERROR("Failed to connect to tf_service server.");
+    ROS_ERROR_STREAM("Failed to connect to tf_service server.");
     return false;
   }
   std::lock_guard<std::mutex> guard(mutex_);

--- a/src/buffer_client.cc
+++ b/src/buffer_client.cc
@@ -105,6 +105,7 @@ void BufferClient::asyncReconnect(const ros::Duration timeout) {
     ROS_WARN("Already asynchronously reconnecting to server.");
     return;
   }
+  ROS_INFO("Asynchronously reconnecting to server.");
   async_reconnected_ =
       std::async(std::launch::async, &BufferClient::reconnect, this, timeout);
 }

--- a/src/python_bindings/buffer_client_py.cc
+++ b/src/python_bindings/buffer_client_py.cc
@@ -83,6 +83,9 @@ PYBIND11_PLUGIN(client_binding) {
       .def("reconnect", &tfs::BufferClient::reconnect,
            /* doc strings for args */
            py::arg("timeout"))
+      .def("async_reconnect", &tfs::BufferClient::asyncReconnect,
+           /* doc strings for args */
+           py::arg("timeout"))
       .def("wait_for_server", &tfs::BufferClient::waitForServer,
            /* doc strings for args */
            py::arg("timeout"));

--- a/src/tf_service/client.py
+++ b/src/tf_service/client.py
@@ -56,6 +56,18 @@ class BufferClient(tf2_ros.BufferInterface):
         return self.client.wait_for_server(timeout)
 
     @translate_exceptions
+    def is_connected(self):
+        return self.client.is_connected()
+
+    @translate_exceptions
+    def reconnect(self, timeout=rospy.Duration(10)):
+        return self.client.reconnect(timeout)
+
+    @translate_exceptions
+    def async_reconnect(self, timeout=rospy.Duration(10)):
+        return self.client.async_reconnect(timeout)
+
+    @translate_exceptions
     def lookup_transform(self, target_frame, source_frame, time,
                          timeout=rospy.Duration(0.0)):
         """

--- a/src/tf_service/client.py
+++ b/src/tf_service/client.py
@@ -16,8 +16,6 @@
 # from geometry2/tf2_ros/src/tf2_ros/buffer_client.py, which is
 # subject to a BSD License. See 3rdparty/geometry2_LICENSE for details.
 
-import typing
-
 import rospy
 # Importing tf2_geometry_msgs to register geometry_msgs
 # types with tf2_ros.TransformRegistration
@@ -35,13 +33,13 @@ class BufferClient(tf2_ros.BufferInterface):
     The interface is exactly the same as the old action-based client.
     """
     @translate_exceptions
-    def __init__(self, server_node_name: str,
-                 keepalive_period: typing.Optional[rospy.Duration] = None):
+    def __init__(self, server_node_name, keepalive_period=None):
         """
         :param server_node_name: name of the tf_service server ROS node
         :param keepalive_period:
-            periodically check the connection to the server
-            and try to reconnect in the background if it dropped
+            rospy.Duration defining how often to periodically check the
+            connection to the server and try to reconnect in the background
+            if it dropped
         """
         tf2_ros.BufferInterface.__init__(self)
         # All actual work is done by the C++ binding.

--- a/test/client_rostest.py
+++ b/test/client_rostest.py
@@ -17,6 +17,7 @@
 
 import unittest
 
+import rosnode
 import rospy
 import tf2_ros
 
@@ -83,7 +84,19 @@ class ClientRostest(unittest.TestCase):
                                          rospy.Time(0), "bla",
                                          rospy.Duration(0.1))
 
+    def test_keepalive(self):
+        buffer = tf_service.BufferClient(EXPECTED_SERVER_NAME,
+                                         keepalive_period=rospy.Duration(1))
+        self.assertTrue(buffer.wait_for_server(rospy.Duration(0.1)))
+        # Assuming the server respawns after ~5 seconds.
+        rosnode.kill_nodes(node_names=[EXPECTED_SERVER_NAME])
+        rospy.sleep(1)
+        self.assertFalse(buffer.is_connected())
+        rospy.sleep(10)
+        self.assertTrue(buffer.is_connected())
+
 
 if __name__ == "__main__":
     import rostest
+    rospy.init_node("client_rostest_py")
     rostest.rosrun("tf_service", "client_rostest_py", ClientRostest)

--- a/test/client_rostest_py.launch
+++ b/test/client_rostest_py.launch
@@ -6,7 +6,8 @@
 
   <!-- Server -->
   <node name="tf_service" pkg="tf_service"
-        type="server" args="--num_threads 5" output="screen" required="true" />
+        type="server" args="--num_threads 5" output="screen" respawn="true"
+        respawn_delay="5" />
 
   <!-- Test node -->
   <test test-name="client_rostest_py" pkg="tf_service"


### PR DESCRIPTION
`asyncReconnect` can be called to reconnect without blocking if the service connection was lost.

Additionally, an optional "keepalive" timer can be started in the client that periodically checks the persistent service connection and launches `asyncReconnect` if needed. The [underlying check is cheap](https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/clients/roscpp/src/libros/service_server_link.cpp#L387), so this should have no real performance impact also at slightly higher rates.
(Automatic triggering of reconnecting in the lookup methods isn't possible without breaking the `BufferInterface` (const qualifiers), so this is not implemented there)

Repeated calls to `reconnect` or `asyncReconnect` don't block each other and a future is used to avoid spawning multiple async threads. The wait in `reconnect` also doesn't block the service client mutex anymore thanks to an additional reconnection mutex.