### PR TITLE
Shield Python client requests with a mutex

### DIFF
--- a/test/client_rostest.py
+++ b/test/client_rostest.py
@@ -20,6 +20,7 @@ import unittest
 import rosnode
 import rospy
 import tf2_ros
+from geometry_msgs.msg import PoseStamped
 
 import tf_service
 
@@ -83,6 +84,33 @@ class ClientRostest(unittest.TestCase):
             buffer.lookup_transform_full("bla", rospy.Time(0), "blub",
                                          rospy.Time(0), "bla",
                                          rospy.Duration(0.1))
+
+    def test_transform(self):
+        """
+        Smoke test for checking that the implicitly inherited transform() method
+        from BufferInterface is usable.
+        """
+        buffer = tf_service.BufferClient(EXPECTED_SERVER_NAME)
+        self.assertTrue(buffer.wait_for_server(rospy.Duration(0.1)))
+        pose = PoseStamped()
+        pose.header.stamp = rospy.Time.now()
+        pose.header.frame_id = EXPECTED_SOURCE_FRAME
+        buffer.transform(pose, EXPECTED_TARGET_FRAME)
+
+    def test_transform_full(self):
+        """
+        Smoke test for checking that the implicitly inherited transform_full()
+        method from BufferInterface is usable.
+        """
+        buffer = tf_service.BufferClient(EXPECTED_SERVER_NAME)
+        self.assertTrue(buffer.wait_for_server(rospy.Duration(0.1)))
+        pose = PoseStamped()
+        now = rospy.Time.now()
+        pose.header.stamp = now
+        pose.header.frame_id = EXPECTED_SOURCE_FRAME
+        buffer.transform_full(
+            pose, EXPECTED_TARGET_FRAME, now, EXPECTED_SOURCE_FRAME, rospy.Duration(1)
+        )
 
     def test_keepalive(self):
         buffer = tf_service.BufferClient(EXPECTED_SERVER_NAME,


### PR DESCRIPTION
This is [part of the C++ client](https://github.com/magazino/tf_service/blob/master/src/buffer_client.cc#L171) but wasn't ported to the pure Python
client when I removed the bindings ([I thought it's not needed](https://github.com/magazino/tf_service/pull/24/commits/0cca9ef9b2581f62e9edffb56c5f85d2efef1996)).

Turns out that this could lead to regression when users do "special" stuff
like putting the client into a singleton that gets accessed by multiple
threads.